### PR TITLE
Updated header description and added convenience structs

### DIFF
--- a/src/sludge.c
+++ b/src/sludge.c
@@ -18,13 +18,23 @@
 
 /* New header format: 
  * size_of_file    st.size
- * file_modes      st.mode
  * hash            uint32_t
- * dupe_flag       uint32_t   *This is for future proofing 
-   offset                     (big archives with big offsets)
- * name_length     size_t
- * file_name       dependent upon value of name_length
+ * file_count      uint8_t
+ * array of fd structs:
+   - file_name       char[256]
+   - perms           mode_t
 */
+
+typedef struct header {
+  st_size    file_size;
+  uint32_t   hash;
+  uint8_t    file_count;
+} header;
+
+typedef struct fd{
+  char       file_name[256];
+  mode_t     perms;
+} fd;
 
 int permissionPrint(mode_t perms) {
   printf( (perms & S_IRUSR) ? "r" : "-");


### PR DESCRIPTION
NOTE:
Each block will now contain the following:
 - One block corresponding to the 'header' struct, giving the file size,
   the file hash, and the number of file descriptors.
 - One or more blocks corresponding to the 'fd' struct, giving the
   file name, and the permissions for each instance.
I chose to limit the file name size for ease, and it can be adjusted
if we see fit, although it will destroy compatibility with old archives